### PR TITLE
Fix deprecation warning under Perl 5.22

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,7 @@ Revision history for Perl distribution Locales
 ???
     - Add v0.33 tests to the .in file
     - simplified Makefile prereqs
+    - rt 105521: Fix regular expression deprecation warning
 
 0.33  2015-01-24 14:55:28
     - Add missing native tlh name for fun and profit

--- a/lib/Locales.pm
+++ b/lib/Locales.pm
@@ -1013,7 +1013,7 @@ sub normalize_for_key_lookup {
 sub plural_rule_string_to_javascript_code {
     my ( $plural_rule_string, $return ) = @_;
     my $perl = plural_rule_string_to_code( $plural_rule_string, $return );
-    $perl =~ s/sub { /function (n) {/;
+    $perl =~ s/sub \{ /function (n) {/;
     $perl =~ s/\$_\[0\]/n/g;
     $perl =~ s/ \(n \% ([0-9]+)\) \+ \(n-int\(n\)\) /n % $1/g;
     $perl =~ s/int\(/parseInt\(/g;


### PR DESCRIPTION
This is a trivial patch to fix the deprecation warnings under Perl 5.22.

Locales 0.33 doesn't build cleanly (depending on the version of ExtUtils::MakeMaker) as its dependency on String::UnicodeUTF8 wasn't always specified. That seems to be fixed already in the code on Github - is it possible to push a new release (even if this patch isn't merged)? Thanks! :)
